### PR TITLE
renamed Graph.Make_graph Graph.Make

### DIFF
--- a/grapherd/graph_api.ml
+++ b/grapherd/graph_api.ml
@@ -1,7 +1,7 @@
 open Core
 open Grapher
    
-module S = Graph.Make_graph (Vertex.Vertex_list)
+module S = Graph.Make (Vertex.Vertex_list)
 
 let max_k = Reachable.of_int 4
 


### PR DESCRIPTION
and my manual CI process failed to run build all. This presents a fix for that issue. 