### PR TITLE
generate test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 .merlin
 node_modules
 *.install
+coverage-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,27 @@
 language: c
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-  - wget https://raw.githubusercontent.com/dinosaure/ocaml-travisci-skeleton/master/.travis-docgen.sh
-script: bash -ex .travis-opam.sh
-sudo: true
-env:
-  global:
-  - PACKAGE=spaces_common
-  - PACKAGE=grapher
-  - PACKAGE=request_manager
-  matrix:
-  - OCAML_VERSION=4.07
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.opam
+    - $HOME/ocaml
+
+install: bash -ex .travis-ci.sh prepare
+script: bash -ex .travis-ci.sh build
+
+matrix:
+  include:
+    - os: linux
+      env: OCAML_VERSION=4.07 OCAML_RELEASE=1 WITH_OPAM=0
+      stage: Build
+    - os: osx
+      env: OCAML_VERSION=4.07 OCAML_RELEASE=1 WITH_OPAM=0
+      stage: Build_macOS
+    - os: linux
+      env: OCAML_VERSION=4.07 OCAML_RELEASE=1 WITH_OPAM=1
+      stage: Test
+      addons:
+        apt:
+          packages:
+            - aspcud
+      

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: coverage-report coveralls
+
+coverage-report:
+	dune clean
+	BISECT_ENABLE=yes dune runtest
+	bisect-ppx-report -I _build/default -html coverage-report/ `find . -name 'bisect*.out'`
+
+coveralls:
+	dune clean
+	BISECT_ENABLE=yes dune runtest
+	bisect-ppx-report -I _build/default -coveralls coveralls.json `find . -name 'bisect*.out'`
+
+

--- a/grapherd/dune
+++ b/grapherd/dune
@@ -3,7 +3,9 @@
  (inline_tests)
  (modules graph_api)
  (preprocess
-  (pps ppx_inline_test))
+  (pps
+    ppx_jane
+    bisect_ppx -conditional -no-comment-parsing))
  (libraries grapher))
 
 (executable

--- a/lib/dune
+++ b/lib/dune
@@ -4,5 +4,7 @@
  (modules graph graph_intf feature_flipper tag semigroup_intf semigroup
    monoid_intf monoid growable_array)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson))
+  (pps ppx_jane
+       ppx_deriving_yojson
+       bisect_ppx -conditional -no-comment-parsing))
  (libraries core ppx_deriving.runtime higher))


### PR DESCRIPTION
run tests using bisect_ppx to generate a test coverage report. Also
allow for generating a coveralls report for uploading.
