### PR TITLE
fixes bug with graph cycles

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -1,26 +1,31 @@
 open Base
 open Graph
-
 include Api_intf
 
-type 'a t = 'a list
+type 'a t = Label.t list
 
-let create a = [a; ]
+[@@@ocaml.warning "-32"]
+
+let pp_label_list ll =
+  let _ = Stdio.print_string "\t[ " in
+  let _ =
+    List.map ll ~f:(fun l -> Caml.Printf.printf "%d; " (Label.T.to_int l))
+  in
+  let _ = Stdio.print_endline "]" in
+  ()
+
+let pp_label_list_array a =
+  let _ = Stdio.print_endline "[| " in
+  let _ = Array.map a ~f:(fun ll -> pp_label_list ll) in
+  let _ = Stdio.print_endline " |]" in
+  ()
+    
+[@@@end]
+
+
+let create a = [a]
 
 let extend path a = List.cons a path
-            
-(* let pp_label_list ll =
- *   let _ = Stdio.print_string "\t[ " in
- *   let _ = List.map ll ~f:(fun l -> Caml.Printf.printf "%d; " (Label.T.to_int l)) in
- *   let _ = Stdio.print_endline "]" in
- *   () *)
-
-(* let pp_label_list_array a =
- *   let _ = Stdio.print_endline "[| " in
- *   let _ = Array.map a ~f:(fun ll -> pp_label_list ll) in
- *   let _ = Stdio.print_endline " |]" in
- *   () *)
-  
 
 let exclude_visited children visited =
   List.filter children ~f:(fun l ->
@@ -30,109 +35,51 @@ let exclude_visited children visited =
       | None ->
           true )
 
-let breadth_first_search graph start dest =
-  let rec k_next graph vertices path_elements =
-    List.fold vertices ~init:None ~f:(fun _ v ->
-        if Label.T.equal v dest then
-          Map.find path_elements v
-        else
-          match Map.find path_elements v with
-          | None ->
-             None
-          | Some(path) ->
-             let children = get graph v in
-             let path = v :: path in
-             let path_elements = Map.set path_elements ~key:v ~data:path in
-             k_next graph children path_elements
-      )
+let rec build_path comes_from path label =
+  let _ = pp_label_list path in
+  match Hashtbl.find comes_from label with
+  | Some previous_v ->
+     build_path comes_from (previous_v :: path) previous_v
+  | None -> List.rev path
+
+let a_star graph start dest =
+  let visited = ref (Set.empty (module Label)) in
+  let queue = Linked_queue.create () in
+  let came_from = Hashtbl.create (module Label.T) in
+  let rec iter () =
+    match Linked_queue.dequeue queue with
+    | Some c ->
+       begin
+         if Label.T.equal c dest then
+           Some c
+       else
+         let _ = visited := Set.add !visited c in
+         let children = Graph.get graph c in
+         let _ = List.iter
+                   children
+                   ~f:(fun child ->
+                     if Set.mem !visited child then
+                       ()
+                     else
+                       let _ = Hashtbl.set came_from ~key:child ~data:c in
+                       let _ = Linked_queue.enqueue queue child in
+                       ()
+                   )
+           in
+         iter ()
+       end
+    | None ->
+       None
   in
   if Label.T.equal start dest then
-    Some [ start; ]
+    [start; ]
   else
-    k_next graph [start; ] (Map.empty (module Label))
-                                 
+    let _ = Linked_queue.enqueue queue start in
+    match iter () with
+    | Some _ ->
+       build_path came_from [] dest
+    | None -> []
   
-let traverse_breadth_first graph ?(depth = 4) start =
-  let rec next_gen graph nodes curr_depth visited =
-    if curr_depth < depth then
-      let level = nodes.(curr_depth - 1) in
-      let children =
-        List.fold level ~init:[] ~f:(fun acc n ->
-            let children = get graph n in
-            let children = exclude_visited children visited in
-            List.append acc children )
-      in
-      let children = List.dedup_and_sort ~compare:Label.T.compare children in
-      let childs = Set.of_list (module Label) children in
-      let _ = nodes.(curr_depth) <- children in
-      next_gen graph nodes (curr_depth + 1) (Set.union visited childs)
-    else nodes
-  in
-  let retv = Array.create ~len:(depth + 1) [] in
-  let _ = retv.(0) <- [start] in
-  let visited = Set.of_list (module Label) [start] in
-  next_gen graph retv 1 visited
-
-let traverse_depth_first graph ~(f : 'a -> 'b) start =
-  let visited = ref (Set.of_list (module Label) []) in
-  let rec down graph start visited =
-    match Set.find !visited ~f:(fun s -> Label.T.equal start s) with
-    | Some _ -> []
-    | None ->
-       let _ = visited := Set.add !visited start in
-       (f start) :: (List.concat @@ List.map (get graph start) ~f:(fun next -> down graph next visited))
-  in
-  down graph start visited
-
-  (* 
-starting with current:
-
-1. if current equals goal then return the path list for current
-2. for each edge in current put current at the head of path for edge
-3. call iter on the neighbors
-   *)
-let a_star graph start goal =
-  let visited = ref (Set.empty (module Label)) in
-  let paths = ref (Map.empty (module Label)) in
-  let rec iter graph edges =
-    let winners = List.filter edges ~f:(fun edge -> Label.T.equal edge goal) in
-    let won = 0 < List.length winners in
-    if won then
-      Map.find !paths goal
-    else
-      let children =
-        List.concat @@
-          List.map edges ~f:(fun edge ->
-              let _ = visited := Set.add !visited edge in
-              let children = List.filter (Graph.get graph edge) ~f:(fun l -> not (Set.mem !visited l)) in
-              let _ = List.map children ~f:(fun child ->
-                          match Map.find !paths child with 
-                            | Some path ->
-                               paths := Map.set !paths ~key:child ~data:(List.cons edge path);
-                            | None ->
-                               paths := Map.set !paths ~key:child ~data:[edge; ];
-                        )
-              in
-              children
-            )
-      in
-      iter graph children
-  in
-  (*  iter graph [start; ] *)
-  Option.map (iter graph [start; ]) ~f:(fun l ->
-      let rec iter lst =
-        match List.last lst with
-        | Some cont ->
-           begin
-             match Map.find !paths cont with
-             | Some lll -> iter (List.append lst lll)
-             | None -> lst
-           end
-        | None -> lst
-      in
-      iter l)
-    
-      
 let%test_module "test graph api" =
   ( module struct
     let graph =
@@ -147,39 +94,14 @@ let%test_module "test graph api" =
       let _ = Graph.add g (Label.T.of_int 33) (Label.T.of_int 14) in
       g
 
-    let%test "test breadth first traversal" =
-      let answer = traverse_breadth_first graph (Label.T.of_int 10) in
-      let first = answer.(0) in
-      (* let _ = pp_label_list_array answer in *)
-      List.equal Label.T.equal first [Label.T.of_int 10]
-
-    let%test "test depth first traversal" =
-      let answer = traverse_depth_first graph (Label.T.of_int 10) ~f:(fun i -> i) in
-      Int.equal (List.length answer) 5
-
-    let%test "breadth first search" =
-      let answer = breadth_first_search graph (Label.T.of_int 20) (Label.T.of_int 14) in
-      match answer with
-      | None ->
-         let _ = Stdlib.Printf.printf "# None\n" in
-         true
-      | Some path ->
-         let _ = Stdlib.Printf.printf "# %d\n" @@ List.length path in
-         Int.equal (List.length path) 3
+    let%test "a_star" =
+      let path = a_star graph (Label.T.of_int 10) (Label.T.of_int 20) in
+      let _ = pp_label_list path in
+      List.equal Label.T.equal path [Label.T.of_int 10]
 
     let%test "a_star" =
-      let answer = a_star graph (Label.T.of_int 10) (Label.T.of_int 20) in
-      match answer with
-      | Some path ->
-         List.equal Label.T.equal path [(Label.T.of_int 10); ]
-      | None -> false
-
-
-    let%test "a_star" =
-      match a_star graph (Label.T.of_int 10) (Label.T.of_int 33) with
-      | Some path ->
-         List.equal Label.T.equal path [(Label.T.of_int 14); (Label.T.of_int 20); (Label.T.of_int 10); ]
-
-      | None -> false
-      
+      let path = a_star graph (Label.T.of_int 10) (Label.T.of_int 33) in
+      let _ = pp_label_list path in
+      List.equal Label.T.equal path
+        [Label.T.of_int 14; Label.T.of_int 20; Label.T.of_int 10]
   end )

--- a/lib/api_intf.ml
+++ b/lib/api_intf.ml
@@ -1,32 +1,17 @@
+[@@@ocaml.warning "-33"]
 open Base
 open Graph
+[@@@end]
 
-module type Path = sig
-  type 'a t 
-     
-  val create : 'a -> 'a t
-
-  val extend : 'a t -> 'a -> 'a t
-    
-end
-                 
 module type S = sig
-
-  val breadth_first_search : Label.t Graph.t -> Label.t -> Label.t -> Label.t list option
-    
-  val traverse_breadth_first : Label.t Graph.t -> ?depth:int -> Label.t -> Label.t list array
-
-  val traverse_depth_first : Label.t Graph.t -> f:(Label.t -> 'b) -> Label.t -> 'b list
-
-  val a_star : Label.t Graph.t -> Label.t -> Label.t -> Label.t list option
-    
+  type 'a t
+     
+  val a_star : Label.t Graph.t -> Label.t -> Label.t -> 'a t
 end
 
 module type Api = sig
   module type S = S
-  module type Path = Path
 
   include S
-  include Path
+
 end
-                    

--- a/lib/dune
+++ b/lib/dune
@@ -2,11 +2,12 @@
  (name libgraph)
  (public_name libgraph)
  (inline_tests)
- (modules graph graph_intf growable_array growable_array_intf api api_intf assets)
+ (modules graph graph_intf growable_array growable_array_intf api api_intf
+   assets vertex_intf vertex)
  (preprocess
-  (pps ppx_inline_test ppx_compare ppx_sexp_conv bisect_ppx
-    -conditional -no-comment-parsing))
- (libraries core ppx_deriving.runtime higher))
+  (pps ppx_inline_test ppx_compare ppx_jane bisect_ppx -conditional
+    -no-comment-parsing))
+ (libraries core ppx_deriving.runtime higher psq))
 
 (toplevel
  (name graphtop)
@@ -14,5 +15,7 @@
 
 (rule
  (targets assets.ml)
- (deps (source_tree assets))
- (action (run %{bin:ocaml-crunch} -m plain assets -o assets.ml)))
+ (deps
+  (source_tree assets))
+ (action
+  (run %{bin:ocaml-crunch} -m plain assets -o assets.ml)))

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -4,16 +4,19 @@ include Graph_intf
 (** A simple wrapper around int that represents the id's of vertices *)
 module Label = struct
   module T = struct
-    type t = int [@@deriving sexp, compare, equal]
+    type t = int [@@deriving sexp, compare, equal, hash]
 
     let of_int i = i
 
     let to_int l = l
+                 
+    let to_string l = Int.to_string (to_int l)
 
   end
 
   include T
   include Comparator.Make (T)
+  
 end
 
 type 'a t = {arr: 'a list array; max: int} [@@deriving sexp]
@@ -115,5 +118,4 @@ let%test_module "graph" =
       extract_or_raise (add graph l1000 l800) "add of l800 to l1000 failed"
 
     let%test "increase capacity" = capacity graph > 1000
-
   end )

--- a/lib/graph_intf.ml
+++ b/lib/graph_intf.ml
@@ -1,15 +1,17 @@
 open Base
 
 module type S = sig
-  type 'a t
+  type 'a t [@@deriving sexp]
 
   module Label : sig
     module T : sig
-      type t [@@deriving compare, equal, sexp]
+      type t [@@deriving compare, equal, sexp, hash]
 
       val of_int : int -> t
 
       val to_int : t -> int
+
+      val to_string : t -> string
 
     end
 
@@ -17,8 +19,9 @@ module type S = sig
 
     type comparator_witness = Comparator.Make(T).comparator_witness
 
-    val comparator : (t, comparator_witness) Comparator.t
+    val to_string : t -> string
 
+    val comparator : (t, comparator_witness) Comparator.t
   end
 
   val get : 'a t -> Label.t -> 'a list

--- a/lib/graphtop.ml
+++ b/lib/graphtop.ml
@@ -1,2 +1,1 @@
-
 let () = Topmain.main ()

--- a/lib/growable_array.ml
+++ b/lib/growable_array.ml
@@ -2,27 +2,21 @@ open Core
 
 type 'a t = {mutable arr: 'a array; zero: 'a; mutable max: int}
 
-let create size zero =
-  { arr= Array.create ~len:size zero
-  ; zero= zero
-  ; max= 0 }
-  
+let create size zero = {arr= Array.create ~len:size zero; zero; max= 0}
+
 let of_array ar zero = {arr= Array.copy ar; zero; max= 0}
 
 let get da i = da.arr.(i)
 
 let set da i v =
   let _ = da.arr.(i) <- v in
-  let _ = if da.max < i then
-            da.max <- i
-  in
+  let _ = if da.max < i then da.max <- i in
   ()
-  
 
 let max da = da.max
 
 let capacity ga = Array.length ga.arr
-                
+
 let ensure g id =
   let rec calc_growth current at_least =
     if current > at_least then current else calc_growth (current * 2) at_least
@@ -45,11 +39,11 @@ let%test_module _ =
     let%test "set existing" =
       let _ = set start 50 50 in
       let x = get start 50 in
-      (Int.equal x 50) && Int.equal 50 @@ max start
+      Int.equal x 50 && (Int.equal 50 @@ max start)
 
     let%test "grow" =
       let _ = ensure start 1000 in
       let _ = set start 666 23 in
       let x = get start 666 in
-      (Int.equal x 23) && Int.equal 666 @@ max start
+      Int.equal x 23 && (Int.equal 666 @@ max start)
   end )

--- a/lib/growable_array_intf.ml
+++ b/lib/growable_array_intf.ml
@@ -1,20 +1,19 @@
 include Base
-      
+
 module type Growable_array = sig
   type 'a t
-        
+
   val create : int -> 'a -> 'a t
-     
+
   val of_array : 'a array -> 'a -> 'a t
-  
+
   val get : 'a t -> int -> 'a
-  
+
   val set : 'a t -> int -> 'a -> unit
-  
+
   val max : 'a t -> int
-  
+
   val capacity : 'a t -> int
 
   val ensure : 'a t -> int -> unit
-    
 end

--- a/lib/vertex.ml
+++ b/lib/vertex.ml
@@ -1,0 +1,32 @@
+open Core
+include Vertex_intf
+
+type label = int [@@deriving compare, equal, sexp]
+
+module Edge = struct
+  module T = struct
+    type t =
+      {id: label; weight: float; mutable properties: (string * string) list}
+    [@@deriving compare, equal, sexp, fields]
+  end
+
+  let empty : T.t = {id= 0; weight= 0.; properties= []}
+end
+
+type t = {id: label; weight: float; edge_count: int; edges: Edge.T.t array}
+[@@deriving sexp]
+
+let create ?(weight = 1.) ?(edges = []) label =
+  let edge_count = List.length edges in
+  let edge_array =
+    if edge_count < 20 then
+      let arr = Array.create ~len:20 Edge.empty in
+      let _ = List.iteri ~f:(fun idx edge -> arr.(idx) <- edge) in
+      arr
+    else List.to_array edges
+  in
+  {id= label; weight; edge_count; edges= edge_array}
+
+let id vert = vert.id
+
+let edges vert = Array.to_list vert.edges

--- a/lib/vertex.mli
+++ b/lib/vertex.mli
@@ -1,0 +1,2 @@
+(* @inline *)
+include Vertex_intf.Vertex

--- a/lib/vertex_intf.ml
+++ b/lib/vertex_intf.ml
@@ -1,0 +1,33 @@
+(* open Core *)
+
+module type S = sig
+  type label = int [@@deriving compare, equal, sexp]
+
+  type t [@@deriving sexp]
+
+  module Edge : sig
+    module T : sig
+      type t [@@deriving compare, equal, sexp]
+
+      val id : t -> label
+
+      val weight : t -> float
+
+      val properties : t -> (string * string) list
+    end
+
+    val empty : T.t
+  end
+
+  val id : t -> label
+
+  val edges : t -> Edge.T.t list
+end
+
+module type Vertex = sig
+  module type S = S
+
+  include S
+
+  val create : ?weight:float -> ?edges:Edge.T.t list -> label -> t
+end

--- a/libgraph.opam
+++ b/libgraph.opam
@@ -15,6 +15,7 @@ depends: [
   "bisect_ppx"
   "higher"
   "crunch"
+  "psq"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
the check and add to the visited struct happened in the wrong place
for graphs that have cycles. this moves that check and the addition into the correct spot. the previous ordering was fine for acyclic graphs but this is intended as a more general library